### PR TITLE
fix: add --ignore-workspace to the pnpm build install command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to `@opensas/sveltekit-adapter-node-iis` will be documented in this file.
 
+## [0.4.1] - 2026-07-02
+
+### Fixed
+
+- Added `--ignore-workspace` to the default pnpm build command. Without it, if the
+  consuming project has a `pnpm-workspace.yaml` at its root (e.g. just to configure
+  `allowBuilds` under pnpm ≥11, with no actual multi-package workspace), pnpm treats
+  the nested output folder as part of that same workspace when walking up the
+  directory tree. That silently absorbs the `pnpm install --production` step into the
+  parent scope — it reports "Already up to date" but installs nothing at all, not even
+  production dependencies, shipping a broken `node_modules` to production.
+
 ## [0.4.0] - 2025-09-04
 
 ### Added

--- a/index.js
+++ b/index.js
@@ -88,8 +88,16 @@ const INSTALL_INFO = {
   npm: { lock: "package-lock.json", command: "npm ci --omit dev" },
   pnpm: {
     lock: "pnpm-lock.yaml",
-    // use node-linker=hoisted to avoid Windows/IIS symlink issues
-    command: "pnpm install --production --config.node-linker=hoisted",
+    // use node-linker=hoisted to avoid Windows/IIS symlink issues.
+    // --ignore-workspace: if the consuming project has a pnpm-workspace.yaml at its
+    // root (e.g. just to configure allowBuilds under pnpm >=11, with no actual
+    // multi-package workspace), pnpm treats this nested `out` folder as part of that
+    // same workspace when walking up the directory tree. That silently absorbs this
+    // install into the parent scope — it reports "Already up to date" but installs
+    // nothing at all, not even production dependencies. --ignore-workspace forces
+    // pnpm to treat `out` as its own independent project root again.
+    command:
+      "pnpm install --production --config.node-linker=hoisted --ignore-workspace",
   },
   yarn: { lock: "yarn.lock", command: "yarn install --production" },
   bun: { lock: "bun.lockb", command: "bun install --production" },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@opensas/sveltekit-adapter-node-iis",
-	"version": "0.4.0",
+	"version": "0.4.1",
 	"description": "Adapter for SvelteKit that generates a Node server for IIS",
 	"keywords": [
 		"sveltekit",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true


### PR DESCRIPTION
Without this flag, if the consuming project has a pnpm-workspace.yaml at its root (e.g. just to configure allowBuilds under pnpm >=11, with no actual multi-package workspace), pnpm treats the nested output folder as part of that same workspace when walking up the directory tree. That silently absorbs the install into the parent scope — it reports "Already up to date" but installs nothing at all, not even production dependencies, shipping a broken node_modules to production.

Verified both ways: without the flag, node_modules ends up empty; with it, it installs correctly. Also confirmed --ignore-workspace is harmless on pnpm 9.15.1 when there's no workspace present (no-op).